### PR TITLE
Bump jwt version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.2] - 2018-09-14
+### Added
+- Bump JWT version. Via [#27](https://github.com/doorkeeper-gem/doorkeeper-jwt/pull/27) by [@pacop](https://github.com/pacop/)
+
 ## [0.2.1] - 2017-06-07
 ### Fixed
 - The `token_headers` proc now passes `opts` like the other config methods. Fixed via #19 by @travisofthenorth.

--- a/doorkeeper-jwt.gemspec
+++ b/doorkeeper-jwt.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jwt", "~> 1.5.2", ">= 1.5.2"
+  spec.add_dependency "jwt", "~> 2.1.0", ">= 2.1.0"
 
   spec.add_development_dependency "bundler", "~> 1.8", ">= 1.8"
   spec.add_development_dependency "rake", "~> 10.0", ">= 10.0"

--- a/lib/doorkeeper-jwt.rb
+++ b/lib/doorkeeper-jwt.rb
@@ -41,7 +41,7 @@ module Doorkeeper
       end
 
       def encryption_method
-        return nil unless Doorkeeper::JWT.configuration.encryption_method
+        return "none" unless Doorkeeper::JWT.configuration.encryption_method
         Doorkeeper::JWT.configuration.encryption_method.to_s.upcase
       end
 

--- a/spec/doorkeeper-jwt/doorkeeper-jwt_spec.rb
+++ b/spec/doorkeeper-jwt/doorkeeper-jwt_spec.rb
@@ -14,7 +14,6 @@ describe Doorkeeper::JWT do
       decoded_token = ::JWT.decode(token, nil, false)
       expect(decoded_token[0]).to be_a(Hash)
       expect(decoded_token[0]["token"]).to be_a(String)
-      expect(decoded_token[1]["typ"]).to eq "JWT"
       expect(decoded_token[1]["alg"]).to eq "none"
     end
 
@@ -31,7 +30,6 @@ describe Doorkeeper::JWT do
       decoded_token = ::JWT.decode(token, nil, false)
       expect(decoded_token[0]).to be_a(Hash)
       expect(decoded_token[0]["foo"]).to eq "bar"
-      expect(decoded_token[1]["typ"]).to eq "JWT"
       expect(decoded_token[1]["alg"]).to eq "none"
     end
 
@@ -47,7 +45,6 @@ describe Doorkeeper::JWT do
       token = Doorkeeper::JWT.generate(application: { uid: "foo" })
       decoded_token = ::JWT.decode(token, nil, false)
       expect(decoded_token[1]).to be_a(Hash)
-      expect(decoded_token[1]["typ"]).to eq "JWT"
       expect(decoded_token[1]["alg"]).to eq "none"
       expect(decoded_token[1]["kid"]).to eq "foo"
     end
@@ -61,7 +58,6 @@ describe Doorkeeper::JWT do
       decoded_token = ::JWT.decode(token, "super secret", false)
       expect(decoded_token[0]).to be_a(Hash)
       expect(decoded_token[0]["token"]).to be_a(String)
-      expect(decoded_token[1]["typ"]).to eq "JWT"
       expect(decoded_token[1]["alg"]).to eq "none"
     end
 
@@ -76,7 +72,6 @@ describe Doorkeeper::JWT do
       decoded_token = ::JWT.decode(token, "super secret", true, algorithm)
       expect(decoded_token[0]).to be_a(Hash)
       expect(decoded_token[0]["token"]).to be_a(String)
-      expect(decoded_token[1]["typ"]).to eq "JWT"
       expect(decoded_token[1]["alg"]).to eq "HS256"
     end
 
@@ -96,7 +91,6 @@ describe Doorkeeper::JWT do
       decoded_token = ::JWT.decode(token, "super secret", true, algorithm)
       expect(decoded_token[0]).to be_a(Hash)
       expect(decoded_token[0]["foo"]).to eq "bar"
-      expect(decoded_token[1]["typ"]).to eq "JWT"
       expect(decoded_token[1]["alg"]).to eq "HS256"
     end
 
@@ -116,7 +110,6 @@ describe Doorkeeper::JWT do
       decoded_token = ::JWT.decode(token, "super secret", true, algorithm)
       expect(decoded_token[0]).to be_a(Hash)
       expect(decoded_token[0]["foo"]).to eq "bar_1"
-      expect(decoded_token[1]["typ"]).to eq "JWT"
       expect(decoded_token[1]["alg"]).to eq "HS256"
     end
 
@@ -136,7 +129,6 @@ describe Doorkeeper::JWT do
       decoded_token = ::JWT.decode(token, secret_key, true, algorithm: "RS512")
       expect(decoded_token[0]).to be_a(Hash)
       expect(decoded_token[0]["foo"]).to eq "bar"
-      expect(decoded_token[1]["typ"]).to eq "JWT"
       expect(decoded_token[1]["alg"]).to eq "RS512"
     end
 
@@ -156,7 +148,6 @@ describe Doorkeeper::JWT do
       decoded_token = ::JWT.decode(token, secret_key, true, algorithm: "RS512")
       expect(decoded_token[0]).to be_a(Hash)
       expect(decoded_token[0]["foo"]).to eq "bar"
-      expect(decoded_token[1]["typ"]).to eq "JWT"
       expect(decoded_token[1]["alg"]).to eq "RS512"
     end
 
@@ -177,7 +168,6 @@ describe Doorkeeper::JWT do
       decoded_token = ::JWT.decode(token, secret_key, true, algorithm: "ES512")
       expect(decoded_token[0]).to be_a(Hash)
       expect(decoded_token[0]["foo"]).to eq "bar"
-      expect(decoded_token[1]["typ"]).to eq "JWT"
       expect(decoded_token[1]["alg"]).to eq "ES512"
     end
 
@@ -201,7 +191,6 @@ describe Doorkeeper::JWT do
       decoded_token = ::JWT.decode(token, public_key, true, algorithm: "ES512")
       expect(decoded_token[0]).to be_a(Hash)
       expect(decoded_token[0]["foo"]).to eq "bar"
-      expect(decoded_token[1]["typ"]).to eq "JWT"
       expect(decoded_token[1]["alg"]).to eq "ES512"
     end
 
@@ -219,10 +208,9 @@ describe Doorkeeper::JWT do
       end
 
       token = Doorkeeper::JWT.generate(application: { secret: secret_key })
-      decoded_token = ::JWT.decode(token, secret_key, "RS512")
+      decoded_token = ::JWT.decode(token, secret_key, true, algorithm: "RS512")
       expect(decoded_token[0]).to be_a(Hash)
       expect(decoded_token[0]["foo"]).to eq "bar"
-      expect(decoded_token[1]["typ"]).to eq "JWT"
       expect(decoded_token[1]["alg"]).to eq "RS512"
     end
   end


### PR DESCRIPTION
New version of JWT doesn't have _type_ parameter, so it has been completely removed. _algorithm_ param is now mandatory, so nil has been changed to 'none'. 

No additional changes have been required.