### PR TITLE
Add support of new doorkeeper with encryption

### DIFF
--- a/doorkeeper-jwt.gemspec
+++ b/doorkeeper-jwt.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'jwt', '~> 2.1'
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler', '>= 1.16', '< 3'
   spec.add_development_dependency 'pry', '~> 0'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.8'

--- a/lib/doorkeeper/jwt.rb
+++ b/lib/doorkeeper/jwt.rb
@@ -61,14 +61,26 @@ module Doorkeeper
           )
         end
 
-        if opts[:application][:secret].nil?
+        secret = if opts[:application].respond_to?(:plaintext_secret)
+                   unless opts[:application].secret_strategy.allows_restoring_secrets?
+                     raise(
+                       "JWT `use_application_secret` is enabled, but secret strategy " \
+                       "doesn't allow plaintext secret restoring"
+                     )
+                   end
+                   opts[:application].plaintext_secret
+                 else
+                   opts[:application][:secret]
+                 end
+
+        if secret.nil?
           raise(
             'JWT `use_application_secret` is enabled, but the application' \
             ' secret is nil.'
           )
         end
 
-        opts[:application][:secret]
+        secret
       end
 
       def rsa_encryption?


### PR DESCRIPTION
Small change to gem to support new doorkeeper encryption feature. Tried to make it backward compatible.

P.S.: Maybe it worth to add check `if secret_strategy.allows_restoring_secrets?` else raise exception