### PR TITLE
Rename encryption_method to signing_method

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Doorkeeper::JWT.configure do
   # `secret_key_path` will be ignored.
   use_application_secret false
 
-  # Set the encryption secret. This would be shared with any other applications
+  # Set the signing secret. This would be shared with any other applications
   # that should be able to read the payload of the token. Defaults to "secret".
   secret_key ENV['JWT_SECRET']
 
@@ -84,9 +84,9 @@ Doorkeeper::JWT.configure do
   # `secret_key`.
   secret_key_path File.join('path', 'to', 'file.pem')
 
-  # Specify encryption type (https://github.com/progrium/ruby-jwt). Defaults to
+  # Specify cryptographic signing algorithm type (https://github.com/progrium/ruby-jwt). Defaults to
   # `nil`.
-  encryption_method :hs512
+  signing_method :hs512
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ Doorkeeper::JWT.configure do
   use_application_secret false
 
   # Set the signing secret. This would be shared with any other applications
-  # that should be able to read the payload of the token. Defaults to "secret".
+  # that should be able to verify the authenticity of the token. Defaults to "secret".
   secret_key ENV['JWT_SECRET']
 
-  # If you want to use RS* encoding specify the path to the RSA key to use for
+  # If you want to use RS* algorithms specify the path to the RSA key to use for
   # signing. If you specify a `secret_key_path` it will be used instead of
   # `secret_key`.
   secret_key_path File.join('path', 'to', 'file.pem')

--- a/lib/doorkeeper/jwt.rb
+++ b/lib/doorkeeper/jwt.rb
@@ -11,7 +11,7 @@ module Doorkeeper
         ::JWT.encode(
           token_payload(opts),
           secret_key(opts),
-          encryption_method,
+          signing_method,
           token_headers(opts)
         )
       end
@@ -31,22 +31,22 @@ module Doorkeeper
 
         return application_secret(opts) if use_application_secret?
         return secret_key_file unless secret_key_file.nil?
-        return rsa_key if rsa_encryption?
-        return ecdsa_key if ecdsa_encryption?
+        return rsa_key if rsa_signing?
+        return ecdsa_key if ecdsa_signing?
 
         Doorkeeper::JWT.configuration.secret_key
       end
 
       def secret_key_file
         return nil if Doorkeeper::JWT.configuration.secret_key_path.nil?
-        return rsa_key_file if rsa_encryption?
-        return ecdsa_key_file if ecdsa_encryption?
+        return rsa_key_file if rsa_signing?
+        return ecdsa_key_file if ecdsa_signing?
       end
 
-      def encryption_method
-        return "none" unless Doorkeeper::JWT.configuration.encryption_method
+      def signing_method
+        return "none" unless Doorkeeper::JWT.configuration.signing_method
 
-        Doorkeeper::JWT.configuration.encryption_method.to_s.upcase
+        Doorkeeper::JWT.configuration.signing_method.to_s.upcase
       end
 
       def use_application_secret?
@@ -83,12 +83,12 @@ module Doorkeeper
         secret
       end
 
-      def rsa_encryption?
-        /RS\d{3}/ =~ encryption_method
+      def rsa_signing?
+        /RS\d{3}/ =~ signing_method
       end
 
-      def ecdsa_encryption?
-        /ES\d{3}/ =~ encryption_method
+      def ecdsa_signing?
+        /ES\d{3}/ =~ signing_method
       end
 
       def rsa_key

--- a/lib/doorkeeper/jwt/config.rb
+++ b/lib/doorkeeper/jwt/config.rb
@@ -39,8 +39,13 @@ module Doorkeeper
           @config.instance_variable_set("@secret_key_path", value)
         end
 
+        # For backward compatibility. This library does not support encryption.
         def encryption_method(value)
-          @config.instance_variable_set("@encryption_method", value)
+          @config.instance_variable_set("@signing_method", value)
+        end
+
+        def signing_method(value)
+          @config.instance_variable_set("@signing_method", value)
         end
       end
 
@@ -118,7 +123,7 @@ module Doorkeeper
       option :use_application_secret, default: false
       option :secret_key, default: nil
       option :secret_key_path, default: nil
-      option :encryption_method, default: nil
+      option :signing_method, default: nil
 
       def use_application_secret
         @use_application_secret ||= false
@@ -132,8 +137,8 @@ module Doorkeeper
         @secret_key_path ||= nil
       end
 
-      def encryption_method
-        @encryption_method ||= nil
+      def signing_method
+        @signing_method ||= nil
       end
     end
   end

--- a/spec/doorkeeper/jwt/configuration_spec.rb
+++ b/spec/doorkeeper/jwt/configuration_spec.rb
@@ -41,19 +41,19 @@ describe(Doorkeeper::JWT, "#configuration") do
     end
   end
 
-  describe "encryption_method" do
+  describe "signing_method" do
     it "defaults to nil" do
       described_class.configure {}
 
-      expect(configuration.encryption_method).to be_nil
+      expect(configuration.signing_method).to be_nil
     end
 
     it "can change the value" do
       described_class.configure do
-        encryption_method :rs512
+        signing_method :rs512
       end
 
-      expect(configuration.encryption_method).to eq :rs512
+      expect(configuration.signing_method).to eq :rs512
     end
   end
 

--- a/spec/doorkeeper/jwt_spec.rb
+++ b/spec/doorkeeper/jwt_spec.rb
@@ -65,7 +65,7 @@ describe Doorkeeper::JWT do
       expect(decoded_token[1]["alg"]).to eq "none"
     end
 
-    it "creates a signed JWT token" do
+    it "creates a signed JWT token using hs256" do
       described_class.configure do
         secret_key "super secret"
         signing_method :hs256
@@ -120,7 +120,6 @@ describe Doorkeeper::JWT do
       expect(decoded_token[1]).to be_a(Hash)
       expect(decoded_token[1]["alg"]).to eq "HS256"
     end
-
 
     it "creates a signed JWT token with a custom dynamic payload" do
       described_class.configure do

--- a/spec/doorkeeper/jwt_spec.rb
+++ b/spec/doorkeeper/jwt_spec.rb
@@ -65,10 +65,10 @@ describe Doorkeeper::JWT do
       expect(decoded_token[1]["alg"]).to eq "none"
     end
 
-    it "creates a signed encrypted JWT token" do
+    it "creates a signed JWT token" do
       described_class.configure do
         secret_key "super secret"
-        encryption_method :hs256
+        signing_method :hs256
       end
 
       token = described_class.generate({})
@@ -81,7 +81,27 @@ describe Doorkeeper::JWT do
       expect(decoded_token[1]["alg"]).to eq "HS256"
     end
 
-    it "creates a signed encrypted JWT token with a custom payload" do
+    it "creates a signed JWT token with a custom payload" do
+      described_class.configure do
+        token_payload do
+          { foo: "bar" }
+        end
+
+        secret_key "super secret"
+        signing_method :hs256
+      end
+
+      token = described_class.generate({})
+      algorithm = { algorithm: "HS256" }
+      decoded_token = ::JWT.decode(token, "super secret", true, algorithm)
+
+      expect(decoded_token[0]).to be_a(Hash)
+      expect(decoded_token[0]["foo"]).to eq "bar"
+      expect(decoded_token[1]).to be_a(Hash)
+      expect(decoded_token[1]["alg"]).to eq "HS256"
+    end
+
+    it "creates a signed JWT token using the deprecated encryption_method" do
       described_class.configure do
         token_payload do
           { foo: "bar" }
@@ -101,14 +121,15 @@ describe Doorkeeper::JWT do
       expect(decoded_token[1]["alg"]).to eq "HS256"
     end
 
-    it "creates a signed encrypted JWT token with a custom dynamic payload" do
+
+    it "creates a signed JWT token with a custom dynamic payload" do
       described_class.configure do
         token_payload do |opts|
           { foo: "bar_#{opts[:resource_owner_id]}" }
         end
 
         secret_key "super secret"
-        encryption_method :hs256
+        signing_method :hs256
       end
 
       token = described_class.generate(resource_owner_id: 1)
@@ -121,14 +142,14 @@ describe Doorkeeper::JWT do
       expect(decoded_token[1]["alg"]).to eq "HS256"
     end
 
-    it "creates a signed JWT token encrypted with an RSA key from a file" do
+    it "creates a signed JWT token with an RSA key from a file" do
       described_class.configure do
         token_payload do
           { foo: "bar" }
         end
 
         secret_key_path "spec/support/1024key.pem"
-        encryption_method :rs512
+        signing_method :rs512
       end
 
       token = described_class.generate({})
@@ -141,7 +162,7 @@ describe Doorkeeper::JWT do
       expect(decoded_token[1]["alg"]).to eq "RS512"
     end
 
-    it "creates a signed JWT token encrypted with an RSA key from a string" do
+    it "creates a signed JWT token with an RSA key from a string" do
       secret_key = OpenSSL::PKey::RSA.new(1024)
 
       described_class.configure do
@@ -150,7 +171,7 @@ describe Doorkeeper::JWT do
         end
 
         secret_key secret_key.to_s
-        encryption_method :rs512
+        signing_method :rs512
       end
 
       token = described_class.generate({})
@@ -162,14 +183,14 @@ describe Doorkeeper::JWT do
       expect(decoded_token[1]["alg"]).to eq "RS512"
     end
 
-    it "creates a signed JWT token encrypted with an ECDSA key from a file" do
+    it "creates a signed JWT token with an ECDSA key from a file" do
       described_class.configure do
         token_payload do
           { foo: "bar" }
         end
 
         secret_key_path "spec/support/512key.pem"
-        encryption_method :es512
+        signing_method :es512
       end
 
       token = described_class.generate({})
@@ -183,7 +204,7 @@ describe Doorkeeper::JWT do
       expect(decoded_token[1]["alg"]).to eq "ES512"
     end
 
-    it "creates a signed JWT token encrypted with an ECDSA key from a string" do
+    it "creates a signed JWT token with an ECDSA key from a string" do
       secret_key = OpenSSL::PKey::EC.new("secp521r1")
       secret_key.generate_key
       public_key = OpenSSL::PKey::EC.new secret_key
@@ -195,7 +216,7 @@ describe Doorkeeper::JWT do
         end
 
         secret_key secret_key
-        encryption_method :es512
+        signing_method :es512
       end
 
       token = described_class.generate({})
@@ -228,11 +249,11 @@ describe Doorkeeper::JWT do
             { foo: "bar" }
           end
 
-          encryption_method :rs512
+          signing_method :rs512
         end
       end
 
-      it "creates a signed JWT token encrypted with an app secret", :aggregate_failures do
+      it "creates a signed JWT token with an app secret", :aggregate_failures do
         token = described_class.generate(application: application)
         decoded_token = ::JWT.decode(token, secret_key, true, algorithm: "RS512")
 
@@ -258,11 +279,11 @@ describe Doorkeeper::JWT do
             { foo: "bar" }
           end
 
-          encryption_method :rs512
+          signing_method :rs512
         end
       end
 
-      it "creates a signed JWT token encrypted with an app secret", :aggregate_failures do
+      it "creates a signed JWT token with an app secret", :aggregate_failures do
         token = described_class.generate(application: application)
         decoded_token = ::JWT.decode(token, secret_key, true, algorithm: "RS512")
 
@@ -294,11 +315,11 @@ describe Doorkeeper::JWT do
             { foo: "bar" }
           end
 
-          encryption_method :rs512
+          signing_method :rs512
         end
       end
 
-      it "creates a signed JWT token encrypted with an app secret", :aggregate_failures do
+      it "creates a signed JWT token with an app secret", :aggregate_failures do
         expect { described_class.generate(application: application) }.to(
           raise_error.with_message(/secret strategy doesn't/)
         )


### PR DESCRIPTION
This library does ***not*** do encryption and the JWT tokens are readable by anyone.

Using the word "encryption" makes it seem it is safe to store sensible data in the payload when it is clearly not. Encrypted JWT tokens are called JWE tokens and are not supported by this library or by ruby-jwt.

What this library does however is signing the tokens to ensure they were created by a trusted party.

I renamed encryption_method to signing_method and updated the README to specify "signing" instead of "encryption".
It is still possible to use encryption_method for backward compatibility but this now deprecated.