### PR TITLE
Fix default token generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## master
 
-### Changed
+### Fixed
+
+- Fixed default token generation to return a random hex value [#56](https://github.com/doorkeeper-gem/doorkeeper-jwt/pull/56)
 
 ## [0.4.1] - 2022-02-23
 

--- a/lib/doorkeeper/jwt/config.rb
+++ b/lib/doorkeeper/jwt/config.rb
@@ -111,7 +111,7 @@ module Doorkeeper
 
       option(
         :token_payload,
-        default: proc { { token: SecureRandom.method(:hex) } }
+        default: proc { { token: SecureRandom.hex } }
       )
 
       option :token_headers, default: proc { {} }

--- a/lib/doorkeeper/jwt/config.rb
+++ b/lib/doorkeeper/jwt/config.rb
@@ -111,7 +111,7 @@ module Doorkeeper
 
       option(
         :token_payload,
-        default: proc { { token: SecureRandom.hex } }
+        default: proc { { token: SecureRandom.hex } },
       )
 
       option :token_headers, default: proc { {} }

--- a/spec/doorkeeper/jwt_spec.rb
+++ b/spec/doorkeeper/jwt_spec.rb
@@ -15,7 +15,7 @@ describe Doorkeeper::JWT do
       decoded_token = ::JWT.decode(token, nil, false)
 
       expect(decoded_token[0]).to be_a(Hash)
-      expect(decoded_token[0]["token"]).to be_a(String)
+      expect(decoded_token[0]["token"]).to match(/^\h{32}$/)
       expect(decoded_token[1]).to be_a(Hash)
       expect(decoded_token[1]["alg"]).to eq "none"
     end


### PR DESCRIPTION
Fixes https://github.com/doorkeeper-gem/doorkeeper-jwt/issues/32 so that a random hex token is generated by default.