### PR TITLE
Fix option redefinition warnings on gem load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## master
 
+- Fix `[DOORKEEPER] Option ... already defined and will be overridden` warnings on gem load [#61](https://github.com/doorkeeper-gem/doorkeeper-jwt/pull/61)
 - Add your entry here
 
 ## [0.4.3] - 2026-07-20

--- a/lib/doorkeeper/jwt/config.rb
+++ b/lib/doorkeeper/jwt/config.rb
@@ -29,26 +29,10 @@ module Doorkeeper
           @config
         end
 
-        def use_application_secret(value)
-          @config.instance_variable_set("@use_application_secret", value)
-        end
-
-        def secret_key(value)
-          @config.instance_variable_set("@secret_key", value)
-        end
-
-        def secret_key_path(value)
-          @config.instance_variable_set("@secret_key_path", value)
-        end
-
         # For backward compatibility. This library does not support encryption.
         def encryption_method(value)
           @config.instance_variable_set("@signing_method", value)
           Kernel.warn("[DOORKEEPER-JWT]: Please use signing_method instead, this option is deprecated and will be removed soon")
-        end
-
-        def signing_method(value)
-          @config.instance_variable_set("@signing_method", value)
         end
       end
 

--- a/spec/doorkeeper/jwt/configuration_spec.rb
+++ b/spec/doorkeeper/jwt/configuration_spec.rb
@@ -1,9 +1,22 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "open3"
 
 describe(Doorkeeper::JWT, "#configuration") do
   subject(:configuration) { described_class.configuration }
+
+  describe "loading the gem" do
+    it "does not emit config option redefinition warnings" do
+      lib_dir = File.expand_path("../../../lib", __dir__)
+      code = 'require "active_support/all"; require "doorkeeper/jwt"'
+
+      output, status = Open3.capture2e(Gem.ruby, "-I", lib_dir, "-e", code)
+
+      expect(status).to be_success, output
+      expect(output).not_to include("already defined and will be overridden")
+    end
+  end
 
   describe "token_payload" do
     it "is nil by default" do


### PR DESCRIPTION
## Summary

Since #58 switched to Doorkeeper's core config options DSL, loading the gem emits four warnings:

```
[DOORKEEPER] Option use_application_secret already defined and will be overridden
[DOORKEEPER] Option secret_key already defined and will be overridden
[DOORKEEPER] Option secret_key_path already defined and will be overridden
[DOORKEEPER] Option signing_method already defined and will be overridden
```

These show up on every boot of every app that bundles doorkeeper-jwt 0.4.3.

## Cause

`Config::Builder` still has hand-written writer methods for `use_application_secret` / `secret_key` / `secret_key_path` / `signing_method`, duplicating the `option` DSL declarations below them. Doorkeeper's `Doorkeeper::Config::Option#option` warns and `remove_method`s when the builder already defines a method with the same name — which is exactly what happens here, at gem load time (class definition of `Doorkeeper::JWT::Config`).

## Fix

Remove the hand-written builder methods. They have been dead code all along:

- Pre-0.4.3, the vendored `Option` DSL silently redefined them, so the DSL-generated methods were always the ones actually running.
- The DSL-generated methods have identical semantics (`@config.instance_variable_set("@#{name}", block || args.first)`).

So this change only removes the warnings; runtime behavior is unchanged. The deprecated `encryption_method` alias is kept — it has no matching `option` declaration, so it never triggered the warning.

Compatibility note: `doorkeeper/config/option.rb` with `builder_class` support exists since doorkeeper 5.4, which is what 0.4.3 already effectively requires (`require "doorkeeper/config/option"` fails on < 5.1, and 5.1–5.3 resolve the `Builder` constant to Doorkeeper's own builder). This PR doesn't change that envelope.

## Verification

Before (master):

```console
$ ruby -Ilib -e 'require "active_support/all"; require "doorkeeper/jwt"'
[DOORKEEPER] Option use_application_secret already defined and will be overridden
[DOORKEEPER] Option secret_key already defined and will be overridden
[DOORKEEPER] Option secret_key_path already defined and will be overridden
[DOORKEEPER] Option signing_method already defined and will be overridden
```

After: no output.

- All existing specs pass (the existing configuration specs already cover setting/reading all four options).
- Added a regression spec that loads the gem in a subprocess and asserts no redefinition warnings are emitted.