### PR TITLE
Restore coverage for the deprecated encryption_method option

### DIFF
--- a/spec/doorkeeper/jwt_spec.rb
+++ b/spec/doorkeeper/jwt_spec.rb
@@ -101,15 +101,19 @@ describe Doorkeeper::JWT do
       expect(decoded_token[1]["alg"]).to eq "HS256"
     end
 
-    it "creates a signed JWT token using the deprecated signing_method" do
+    it "creates a signed JWT token using the deprecated encryption_method" do
+      allow(Kernel).to receive(:warn)
+
       described_class.configure do
         token_payload do
           { foo: "bar" }
         end
 
         secret_key "super secret"
-        signing_method :hs256
+        encryption_method :hs256
       end
+
+      expect(Kernel).to have_received(:warn).with(/deprecated/)
 
       token = described_class.generate({})
       algorithm = { algorithm: "HS256" }


### PR DESCRIPTION
## Summary

The example named *"creates a signed JWT token using the deprecated signing_method"* configures `signing_method :hs256`, making it an exact duplicate of the example right above it. The deprecated `encryption_method` option it was meant to cover is never called.

It was added in 9c07ff7 (#53) as a regression test for `encryption_method`, but 7666016 ("Fix CI") rewrote it to use `signing_method`. So the backward-compatibility path in `Config::Builder#encryption_method` — including the deprecation warning added in 818e76d — currently has no coverage.

RuboCop flags the duplicate too:

```
spec/doorkeeper/jwt_spec.rb:104:5: C: RSpec/RepeatedExample:
  Don't repeat examples within an example group. Repeated on line(s) 84.
```

## Changes

Point the example back at `encryption_method` and assert the deprecation warning. Stubbing `Kernel.warn` also keeps it off stderr during test runs.

I verified the restored example catches regressions: removing the `Kernel.warn` line fails the message expectation, and removing `encryption_method` entirely fails with `NoMethodError`. Both go unnoticed on `master` today.
