### PR TITLE
Fix stale links in gem metadata and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Gem Version](https://badge.fury.io/rb/doorkeeper-jwt.svg)](https://rubygems.org/gems/doorkeeper-jwt)
 [![Coverage Status](https://coveralls.io/repos/github/doorkeeper-gem/doorkeeper-jwt/badge.svg?branch=master)](https://coveralls.io/github/doorkeeper-gem/doorkeeper-jwt?branch=master)
-[![Build Status](https://travis-ci.org/doorkeeper-gem/doorkeeper-jwt.svg?branch=master)](https://travis-ci.org/doorkeeper-gem/doorkeeper-jwt)
+[![CI](https://github.com/doorkeeper-gem/doorkeeper-jwt/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/doorkeeper-gem/doorkeeper-jwt/actions/workflows/ci.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/ca4d81b49acabda27e0c/maintainability)](https://codeclimate.com/github/doorkeeper-gem/doorkeeper-jwt/maintainability)
 
 # Doorkeeper::JWT

--- a/doorkeeper-jwt.gemspec
+++ b/doorkeeper-jwt.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata = {
     "homepage_uri" => "https://github.com/doorkeeper-gem/doorkeeper-jwt",
-    "changelog_uri" => "https://github.com/doorkeeper-gem/doorkeeper-jwt/blob/main/CHANGELOG.md",
+    "changelog_uri" => "https://github.com/doorkeeper-gem/doorkeeper-jwt/blob/master/CHANGELOG.md",
     "source_code_uri" => "https://github.com/doorkeeper-gem/doorkeeper-jwt",
     "bug_tracker_uri" => "https://github.com/doorkeeper-gem/doorkeeper-jwt/issues",
     "funding_uri" => "https://opencollective.com/doorkeeper-gem",


### PR DESCRIPTION
Two stale links in the repository metadata:

**`changelog_uri` gem metadata** — points at `blob/main/CHANGELOG.md`, but this repository has no `main` branch; the default branch is `master`. The "Changelog" link on rubygems.org has 404'd for every release since 0.4.3 (bbcd0bf).

```
$ git ls-remote --heads https://github.com/doorkeeper-gem/doorkeeper-jwt.git
... refs/heads/master
```

**README build badge** — still renders a `travis-ci.org` badge, which no longer resolves. `.travis.yml` was removed in d684055 (v0.4.1) and CI has run on GitHub Actions ever since.