### PR TITLE
Declare the supported Doorkeeper range and verify it on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,10 @@ permissions:
 jobs:
   build:
     name: >-
-      Ruby ${{ matrix.ruby }}
+      Ruby ${{ matrix.ruby }} / Doorkeeper ${{ matrix.doorkeeper }}
     env:
       CI: true
+      DOORKEEPER_VERSION: ${{ matrix.doorkeeper }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' || matrix.experimental }}
     if: |
@@ -24,6 +25,11 @@ jobs:
         ruby:
           - '3.0'
           - '3.1'
+        # The minimum declared in the gemspec and the latest release. 5.4 is the oldest
+        # version whose options DSL resolves against our own config builder.
+        doorkeeper:
+          - '5.4.0'
+          - 'latest'
     steps:
       - name: Repo checkout
         uses: actions/checkout@v2
@@ -33,6 +39,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          # Each Doorkeeper pin resolves to a different bundle.
+          cache-version: doorkeeper-${{ matrix.doorkeeper }}
 
       - name: Run tests
         timeout-minutes: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## master
 
 - Fix `[DOORKEEPER] Option ... already defined and will be overridden` warnings on gem load [#61](https://github.com/doorkeeper-gem/doorkeeper-jwt/pull/61)
+- Declare `doorkeeper >= 5.4` as a runtime dependency and verify the supported range on CI [#64](https://github.com/doorkeeper-gem/doorkeeper-jwt/pull/64)
 - Add your entry here
 
 ## [0.4.3] - 2026-07-20

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,12 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in doorkeeper-jwt.gemspec
 gemspec
 
+# Pin Doorkeeper to check a specific version of it against this gem. Unset means
+# "the newest version the gemspec allows"; CI sets it to both ends of the
+# supported range. See .github/workflows/ci.yml.
+doorkeeper_version = ENV.fetch("DOORKEEPER_VERSION", "latest")
+gem "doorkeeper", doorkeeper_version unless doorkeeper_version == "latest"
+
 gem "coveralls_reborn", require: false
 gem "rubocop", "~> 1.8", require: false
 gem "rubocop-rspec", "~> 3.0", require: false

--- a/README.md
+++ b/README.md
@@ -5,11 +5,21 @@
 
 # Doorkeeper::JWT
 
-Doorkeeper JWT adds JWT token support to the Doorkeeper OAuth library. Confirmed to work with Doorkeeper 2.2.x - 4.x.
-Untested with later versions of Doorkeeper.
+Doorkeeper JWT adds JWT token support to the Doorkeeper OAuth library.
 
-```ruby
-gem 'doorkeeper'
+## Compatibility
+
+Requires Doorkeeper 5.4 or newer. Doorkeeper 5.0 and earlier cannot load this gem at all, because they ship no
+`doorkeeper/config/option`. Doorkeeper 5.1 - 5.3 load it but misconfigure it: their options DSL defines the
+methods on Doorkeeper's own config builder instead of this gem's.
+
+The minimum supported version and the latest release run on every CI build - see the `doorkeeper` axis of the matrix
+in [`.github/workflows/ci.yml`](.github/workflows/ci.yml). To check a version that is not covered there, point the
+test suite at it:
+
+```console
+$ DOORKEEPER_VERSION=5.6.0 bundle install
+$ DOORKEEPER_VERSION=5.6.0 bundle exec rake test
 ```
 
 ## Installation

--- a/doorkeeper-jwt.gemspec
+++ b/doorkeeper-jwt.gemspec
@@ -30,10 +30,12 @@ Gem::Specification.new do |spec|
     "funding_uri" => "https://opencollective.com/doorkeeper-gem",
   }
 
+  # Loaded at require time by lib/doorkeeper/jwt/config.rb. The options DSL it
+  # relies on only resolves against our own builder since Doorkeeper 5.4.
+  spec.add_dependency "doorkeeper", ">= 5.4"
   spec.add_dependency "jwt", ">= 2.1"
 
   spec.add_development_dependency "bundler", ">= 1.16"
-  spec.add_development_dependency "doorkeeper"
   spec.add_development_dependency "pry", "~> 0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.8"


### PR DESCRIPTION
Closes #28.

## Summary

Since 1d26f59 (released in 0.4.3) `lib/doorkeeper/jwt/config.rb` requires `doorkeeper/config/option` at load time, yet the gemspec lists doorkeeper only as an **unconstrained development dependency**. Nothing stops Bundler from resolving a version this gem cannot load.

## Measured against the released gems

| Doorkeeper | Result |
|---|---|
| `<= 5.0.x` | `LoadError: cannot load such file -- doorkeeper/config/option` — `config/option.rb` was introduced in 5.1.0 |
| `5.1.0 - 5.3.x` | Loads, but `option` resolves the `Builder` constant lexically to `Doorkeeper::Config::Builder`, so our options are defined on Doorkeeper's own builder rather than ours |
| `>= 5.4.0` | Resolves through `builder_class` and works as intended |

Each row was checked by putting the corresponding released gem on the load path and requiring `doorkeeper/jwt`, then running a `configure` + `generate` round trip.

The README currently says the opposite:

> Confirmed to work with Doorkeeper 2.2.x - 4.x. Untested with later versions of Doorkeeper.

That sentence predates all of this and names exactly the range that cannot load the gem.